### PR TITLE
#26-멤버 컨트롤러에서 멤버 객체가 아닌 ResponseEntity에 성공 메시지 담아서 리턴

### DIFF
--- a/src/main/java/com/sparta/newsfeed/member/controller/MemberRestController.java
+++ b/src/main/java/com/sparta/newsfeed/member/controller/MemberRestController.java
@@ -6,6 +6,7 @@ import com.sparta.newsfeed.member.service.MemberService;
 import com.sparta.newsfeed.security.service.MemberDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,21 +19,22 @@ import java.util.Map;
 @RequestMapping("/api/user")
 public class MemberRestController {
     private final MemberService memberService;
+
     @PutMapping("/{username}")
-    public Map<String, Object> modifycontent(@PathVariable("username") String username
+    public ResponseEntity<Map<String, Object>> modifyContent(@PathVariable("username") String username
             , @RequestBody RequestProfileUpdateDto requestProfileUpdateDto
             , @AuthenticationPrincipal MemberDetailsImpl memberDetails) {
         Map<String, Object> map = new HashMap<>();
         memberService.updateMember(requestProfileUpdateDto, memberDetails);
         map.put("result","success");
-        return map;
+        return ResponseEntity.ok(map);
     }
+
     @PostMapping("/signup")
-    public Map<String, Object> register(@RequestBody SignupDto signupDto) {
+    public ResponseEntity<Map<String, Object>> register(@RequestBody SignupDto signupDto) {
         Map<String, Object> map = new HashMap<>();
         memberService.signup(signupDto);
         map.put("result", "success");
-        return map;
+        return ResponseEntity.ok(map);
     }
-
 }


### PR DESCRIPTION
멤버 컨트롤러에서 처리된 멤버DTO객체를 리턴하기 보다 간단한 메시지만 리턴하는 게 좋을 것 같아 리턴타입 수정

This closes #26 